### PR TITLE
chore: upgrade ci go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          - "1.23"
+          - "1.24"
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
upgrade ci go version